### PR TITLE
fix(extensions.json): fix error: johnsoncodehk.volar not found in mar…

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "johnsoncodehk.volar",
+    "vue.volar",
     "dbaeumer.vscode-eslint",
     "stylelint.vscode-stylelint",
     "esbenp.prettier-vscode",


### PR DESCRIPTION
fix error: johnsoncodehk.volar not found in marketplace

The error message will pop-up when we open project in vs code. Due to plugin changed its name.